### PR TITLE
Mark related referral void on setting void

### DIFF
--- a/frappe_affiliate/frappe_affiliate/doctype/affiliate_referral/affiliate_referral.py
+++ b/frappe_affiliate/frappe_affiliate/doctype/affiliate_referral/affiliate_referral.py
@@ -1,9 +1,53 @@
 # Copyright (c) 2025, rtCamp and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class AffiliateReferral(Document):
-    pass
+    def validate(self):
+        db_is_void = frappe.db.get_value("Affiliate Referral", self.name, "void")
+        if db_is_void != self.void:
+            if self.void:
+                frappe.enqueue(
+                    method=self.make_void,
+                    queue="short",
+                    job_name=f"Make Affiliate Referral {self.name} Void",
+                )
+
+    def make_void(self):
+        linked_referrals = frappe.get_all(
+            "Affiliate Referral",
+            filters={
+                "record_type": "commission",
+                "void": 0,
+                "payment_entry": self.payment_entry,
+            },
+            fields=["name"],
+        )
+        self.make_void_referral(self.name)
+        for referral in linked_referrals:
+            # Note: Using frappe.db.set_value here to avoid recursion while updating linked referrals
+            frappe.db.set_value("Affiliate Referral", referral.name, "void", 1)
+            self.make_void_referral(referral.name)
+
+    def make_void_referral(self, referral_name):
+        if self.name != referral_name:
+            referral_doc = frappe.get_doc("Affiliate Referral", referral_name)
+        else:
+            referral_doc = self
+        new_void_doc = frappe.new_doc("Affiliate Referral")
+        new_void_doc.update(
+            {
+                "sales_partner": referral_doc.sales_partner,
+                "record_type": "void",
+                "void_affiliate_referral": referral_name,
+                "amount": referral_doc.amount,
+                "keyword": referral_doc.keyword,
+                "date": frappe.utils.getdate(),
+                "payment_entry": referral_doc.payment_entry,
+                "tier": referral_doc.tier,
+            }
+        )
+        new_void_doc.insert()


### PR DESCRIPTION
## Description

This pull request introduces logic to handle voiding affiliate referrals in the `AffiliateReferral` DocType. The main change is the addition of methods to automate the voiding process, ensuring that related commission records are properly voided and new void records are created.

## Relevant Technical Choices

* Added a `validate` method to `AffiliateReferral` that triggers the voiding process when the `void` field is changed, using `frappe.enqueue` to run the operation asynchronously.
* Implemented the `make_void` method to void the current referral and all linked commission-type referrals with the same `payment_entry`, updating their `void` status and creating corresponding void records.
* Added the `make_void_referral` method to create a new void-type referral document, duplicating relevant fields from the original referral to ensure proper tracking of voided records.

## Testing Instructions

- [ ] Create multiple referral rule with same payment entry
- [ ] Mark one of them as void
- [ ] All should now be marked as void and new void referrals should be created

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)