### PR TITLE
Make redirect URL dynamic

### DIFF
--- a/frappe_affiliate/affiliate_request_handler.py
+++ b/frappe_affiliate/affiliate_request_handler.py
@@ -41,7 +41,10 @@ def set_cookie(cookie_route_path, cookie_timeout):
     banner_exists = frappe.db.exists(
         "Affiliate Banner and Text Link", {"name": banner, "disabled": 0}
     )
-    banner_url = "/"
+    affiliate_redirect_url = frappe.get_cached_doc(
+        "Affiliate Settings"
+    ).affiliate_redirect_url
+    banner_url = affiliate_redirect_url if affiliate_redirect_url else "/"
     if banner_exists:
         banner_url = get_banner_redirect_url(banner)
     cookie_val = local.request.cookies.get("affiliate_id")

--- a/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.json
+++ b/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.json
@@ -12,6 +12,7 @@
   "subsequent_referral_rate",
   "affiliate_route_path",
   "banner_and_text_link_route_path",
+  "affiliate_redirect_url",
   "enable_keywords_support",
   "banner_and_text_link"
  ],
@@ -73,13 +74,20 @@
    "in_list_view": 1,
    "label": "Subsequent Referral Rate",
    "reqd": 1
+  },
+  {
+   "fieldname": "affiliate_redirect_url",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Affiliate Redirect URL",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-12 15:57:12.328250",
+ "modified": "2025-10-23 21:44:10.978581",
  "modified_by": "Administrator",
  "module": "Frappe Affiliate",
  "name": "Affiliate Settings",


### PR DESCRIPTION
## Description

This pull request adds support for a configurable affiliate redirect URL in the affiliate settings. The main change allows admins to specify a custom redirect URL, which is then used in the affiliate request handler logic.


## Relevant Technical Choices

**Affiliate Settings Enhancements:**

* Added a new field `affiliate_redirect_url` to the `Affiliate Settings` doctype, allowing administrators to set a custom redirect URL for affiliates. [[1]](diffhunk://#diff-7f5cfdef627fb9304bd92466de2c13745e871dc25355819fd134fa752114da1cR15) [[2]](diffhunk://#diff-7f5cfdef627fb9304bd92466de2c13745e871dc25355819fd134fa752114da1cR77-R90)

**Affiliate Request Handler Logic Update:**

* Updated the logic in `set_cookie` in `affiliate_request_handler.py` to use the new `affiliate_redirect_url` from settings if available, falling back to `/` if not set.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)