### PR TITLE
Fix issue with date being today by default

### DIFF
--- a/frappe_affiliate/api/affiliate_keyword.py
+++ b/frappe_affiliate/api/affiliate_keyword.py
@@ -41,8 +41,10 @@ def get_affiliate_keywords(
         "total_count": number
     }
     """
-    date_from = get_datetime(date_from)
-    date_to = get_datetime(date_to)
+    if date_from:
+        date_from = get_datetime(date_from)
+    if date_to:
+        date_to = get_datetime(date_to)
 
     sales_partner = frappe.db.get_value(
         "Sales Partner", {"custom_user": frappe.session.user}, "name"


### PR DESCRIPTION
## Description

Currently when no date is passed, the API returns only data for today. This PR fixes that by ignoring the date filter in case no value is sent.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)