### PR TITLE
Don't set cookie for invalid affiliate

### DIFF
--- a/frappe_affiliate/affiliate_request_handler.py
+++ b/frappe_affiliate/affiliate_request_handler.py
@@ -36,15 +36,32 @@ def set_cookie(cookie_route_path, cookie_timeout):
 
     username = parts[0]
 
-    response = Response("", content_type="text/html")
-    banner = frappe.local.request.args.get("banner")
-    banner_exists = frappe.db.exists(
-        "Affiliate Banner and Text Link", {"name": banner, "disabled": 0}
-    )
+    if not username:
+        return
+
     affiliate_redirect_url = frappe.get_cached_doc(
         "Affiliate Settings"
     ).affiliate_redirect_url
     banner_url = affiliate_redirect_url if affiliate_redirect_url else "/"
+
+    response = Response("", content_type="text/html")
+
+    user_exists = frappe.db.exists("User", {"username": username, "enabled": 1})
+    if not user_exists:
+        redirect_affiliate_link(banner_url, response)
+
+    affiliate_exists = frappe.db.exists(
+        "Sales Partner",
+        {"custom_user": user_exists, "custom_banned": 0, "custom_disabled": 0},
+    )
+
+    if not affiliate_exists:
+        redirect_affiliate_link(banner_url, response)
+
+    banner = frappe.local.request.args.get("banner")
+    banner_exists = frappe.db.exists(
+        "Affiliate Banner and Text Link", {"name": banner, "disabled": 0}
+    )
     if banner_exists:
         banner_url = get_banner_redirect_url(banner)
     cookie_val = local.request.cookies.get("affiliate_id")
@@ -84,9 +101,7 @@ def set_cookie(cookie_route_path, cookie_timeout):
             "affiliate_id", new_val, max_age=60 * 60 * 24 * cookie_timeout
         )
 
-    response.headers["Location"] = banner_url
-    response.status_code = 302
-    raise HTTPException(response=response)
+    redirect_affiliate_link(banner_url, response)
 
 
 def get_banner_redirect_url(banner):
@@ -162,3 +177,9 @@ def check_banner_embed(banner_text_link_route_path):
         """
 
     raise HTTPException(response=Response(js, content_type="application/javascript"))
+
+
+def redirect_affiliate_link(redirect_url, response):
+    response.headers["Location"] = redirect_url
+    response.status_code = 302
+    raise HTTPException(response=response)


### PR DESCRIPTION
## Description

Currently even when an affiliate is disabled their cookie is set. This adds a check to prevent that.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)