### PR TITLE
Lock coupon code to a specific customer

### DIFF
--- a/frappe_affiliate/doc_events/sales_invoice.py
+++ b/frappe_affiliate/doc_events/sales_invoice.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _ as translate
 
 from frappe_affiliate.api.sales_invoice import apply_referral_fee_rules
 
@@ -7,6 +8,9 @@ def validate(doc, method=None):
     coupon_code = doc.get("coupon_code", None)
     if coupon_code:
         coupon_code_doc = frappe.get_doc("Coupon Code", coupon_code)
+        if coupon_code_doc.customer:
+            if coupon_code_doc.customer != doc.customer:
+                frappe.throw(translate("This coupon code is not valid for this user"))
         if (
             coupon_code_doc.custom_sales_partner
             and coupon_code_doc.custom_sales_partner != doc.sales_partner

--- a/frappe_affiliate/doc_events/subscription.py
+++ b/frappe_affiliate/doc_events/subscription.py
@@ -15,6 +15,10 @@ def validate(doc, method=None):
         if not coupon_code_valid:
             frappe.throw(translate("Invalid coupon code"))
 
+        if coupon_code_doc.customer:
+            if coupon_code_doc.customer != doc.party:
+                frappe.throw(translate("This coupon code is not valid for this user"))
+
         coupon_user_use_count = coupon_code_doc.get("custom_maximum_user_use_count", 0)
         if coupon_user_use_count > 0:
             user_use_count = frappe.db.count(
@@ -22,7 +26,7 @@ def validate(doc, method=None):
                 {
                     "party_type": "Customer",
                     "party": doc.party,
-                    "coupon_code": doc.custom_coupon_code,
+                    "custom_coupon_code": doc.custom_coupon_code,
                 },
             )
             if user_use_count >= coupon_user_use_count:

--- a/frappe_affiliate/fixtures/property_setter.json
+++ b/frappe_affiliate/fixtures/property_setter.json
@@ -14,5 +14,21 @@
   "property_type": "Data",
   "row_name": null,
   "value": ""
+ },
+ {
+  "default_value": null,
+  "doc_type": "Coupon Code",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "customer",
+  "is_system_generated": 0,
+  "modified": "2025-10-28 11:50:41.961895",
+  "module": "Frappe Affiliate",
+  "name": "Coupon Code-customer-depends_on",
+  "property": "depends_on",
+  "property_type": "Data",
+  "row_name": null,
+  "value": ""
  }
 ]


### PR DESCRIPTION
## Description

This pull request improves coupon code validation logic in both Sales Invoice and Subscription workflows, ensuring that coupon codes are only used by their assigned customers. It also introduces a property setter for the `customer` field in the `Coupon Code` doctype to support this validation.

**Coupon Code Validation Enhancements**

* Added a check in `frappe_affiliate/doc_events/sales_invoice.py` to ensure that if a coupon code is linked to a specific customer, it can only be applied to invoices for that customer. If not, an error is raised.
* Applied similar validation in `frappe_affiliate/doc_events/subscription.py`, so that coupon codes assigned to a customer cannot be used by other customers in subscriptions.

## Relevant Technical Choices

* Added a property setter to `frappe_affiliate/fixtures/property_setter.json` for the `customer` field in the `Coupon Code` doctype, preparing the field for conditional logic or UI changes.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)