### PR TITLE
Fix affiliate statistics API click count calculation

### DIFF
--- a/frappe_affiliate/api/affiliate_advanced_statistics.py
+++ b/frappe_affiliate/api/affiliate_advanced_statistics.py
@@ -433,14 +433,14 @@ def get_period_statistics(start_date, end_date, user=None):
         "Affiliate Click Log",
         filters={
             "sales_partner": sales_partner,
-            "creation": ["between", [start_datetime, end_datetime]],
+            "time": ["between", [start_datetime, end_datetime]],
         },
     )
     unique_clicks_count = frappe.get_all(
         "Affiliate Click Log",
         filters={
             "sales_partner": sales_partner,
-            "creation": ["between", [start_datetime, end_datetime]],
+            "time": ["between", [start_datetime, end_datetime]],
         },
         fields=["remote_address"],
         group_by="remote_address",


### PR DESCRIPTION
## Description

This PR fixes the `get_affiliate_statistics` API by updating the logic to use the `time` instead of `creation` for calculating `unique_clicks_count` and `clicks_count`.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
