### PR TITLE
Update referral fee rule API for pagination and order

### DIFF
--- a/frappe_affiliate/api/referral_fee_rule.py
+++ b/frappe_affiliate/api/referral_fee_rule.py
@@ -4,7 +4,7 @@ from frappe_affiliate.api.sales_invoice import get_invoice_count
 
 
 @frappe.whitelist()
-def get_referral_fee_rules():
+def get_referral_fee_rules(limit=20, offset=0, order_by="priority asc"):
     referral_fee_rules_list = frappe.get_list(
         "Affiliate Referral Fee Rule",
         fields=[
@@ -16,9 +16,12 @@ def get_referral_fee_rules():
             "comment",
             "apply_on_group",
         ],
-        order_by="priority asc",
+        order_by=order_by,
+        limit_page_length=limit,
+        limit_start=offset,
     )
 
+    result = {}
     referral_fee_rules = []
     for referral_fee_rule in referral_fee_rules_list:
         rule_doc = frappe.get_doc("Affiliate Referral Fee Rule", referral_fee_rule.name)
@@ -45,7 +48,9 @@ def get_referral_fee_rules():
                 "apply_on_group": referral_fee_rule.apply_on_group,
             }
         )
-    return referral_fee_rules
+    result["total"] = frappe.db.count("Affiliate Referral Fee Rule")
+    result["rules"] = referral_fee_rules
+    return result
 
 
 def get_referral_fee_rule_for_tier(doc, group):


### PR DESCRIPTION
## Description

This pull request updates the `get_referral_fee_rules` API to support pagination and custom sorting, and changes its response format to include metadata. These improvements make it easier for clients to fetch referral fee rules efficiently and handle large datasets.

**API enhancements:**

* Added `limit`, `offset`, and `order_by` parameters to `get_referral_fee_rules`, allowing clients to control pagination and sorting of referral fee rules.
* Updated the query in `get_referral_fee_rules` to use the new parameters for pagination and ordering.

**Response format changes:**

* Changed the return value of `get_referral_fee_rules` to a dictionary containing the total count of referral fee rules and the paginated list of rules, instead of just the list.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)