### PR TITLE
Don't allow customer to use their own coupon

### DIFF
--- a/frappe_affiliate/doc_events/subscription.py
+++ b/frappe_affiliate/doc_events/subscription.py
@@ -18,6 +18,17 @@ def validate(doc, method=None):
         if not coupon_code_valid:
             frappe.throw(translate("Invalid coupon code"))
 
+        if coupon_code_doc.custom_sales_partner:
+            sales_partner_customer = frappe.db.get_value(
+                "Sales Partner", coupon_code_doc.custom_sales_partner, "custom_customer"
+            )
+            if doc.party == sales_partner_customer:
+                frappe.throw(
+                    translate(
+                        "Cannot use coupon code assigned to your own affiliate account."
+                    )
+                )
+
         coupon_user_use_count = coupon_code_doc.get("custom_maximum_user_use_count", 0)
         if coupon_user_use_count > 0:
             user_use_count = frappe.db.count(


### PR DESCRIPTION
## Description

This PR adds a check on subscription validate doc_event to prevent a customer from using their own affiliate coupon code.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)