### PR TITLE
Add tier group settings

### DIFF
--- a/frappe_affiliate/api/referral_fee_rule.py
+++ b/frappe_affiliate/api/referral_fee_rule.py
@@ -61,7 +61,10 @@ def get_referral_fee_rule_for_tier(doc, group):
     invoice_item_codes = set(item.item_code for item in doc.items)
     referral_fee_rules = frappe.get_all(
         "Affiliate Referral Fee Rule",
-        filters={"disabled": 0, "apply_on_group": group},
+        filters=[
+            ["disabled", "=", 0],
+            ["Referral User Group", "user_group", "in", group],
+        ],
         fields=["name"],
     )
 

--- a/frappe_affiliate/doc_events/payment_entry.py
+++ b/frappe_affiliate/doc_events/payment_entry.py
@@ -88,6 +88,13 @@ def record_referral_tiers(referral, invoice, payment_entry, tier):
 
     tier_referral_fee_rate = get_referral_fee_rule_for_tier(invoice, tier_user_groups)
 
+    if not tier_referral_fee_rate or tier_referral_fee_rate <= 0:
+        frappe.log_error(
+            message=f"No valid referral fee rate found for tier {tier} for payment entry {payment_entry}",
+            title="Referral Fee Rate Not Found",
+        )
+        return
+
     new_referral = frappe.get_doc(
         {
             "doctype": "Affiliate Referral",

--- a/frappe_affiliate/doc_events/payment_entry.py
+++ b/frappe_affiliate/doc_events/payment_entry.py
@@ -76,6 +76,7 @@ def record_referral_tiers(referral, invoice, payment_entry, tier):
         "User Group Member", filters={"user": sales_partner_user}, pluck="parent"
     )
 
+    # ToDo: investigate if get_list can be used here instead of get_all. If so then replace it.
     tier_user_groups = frappe.get_all(
         "Referral User Group",
         filters={"parentfield": f"tier_{tier}_groups", "parent": "Affiliate Settings"},

--- a/frappe_affiliate/doc_events/payment_entry.py
+++ b/frappe_affiliate/doc_events/payment_entry.py
@@ -83,12 +83,12 @@ def record_referral_tiers(referral, invoice, payment_entry, tier):
         pluck="user_group",
     )
 
-    if set(affiliate_user_group).isdisjoint(tier_user_groups):
+    if tier_user_groups and set(affiliate_user_group).isdisjoint(tier_user_groups):
         return
 
     tier_referral_fee_rate = get_referral_fee_rule_for_tier(invoice, tier_user_groups)
 
-    referral = frappe.get_doc(
+    new_referral = frappe.get_doc(
         {
             "doctype": "Affiliate Referral",
             "sales_partner": parent_sales_partner,
@@ -100,4 +100,4 @@ def record_referral_tiers(referral, invoice, payment_entry, tier):
         }
     ).save()
 
-    return referral
+    return new_referral

--- a/frappe_affiliate/doc_events/payment_entry.py
+++ b/frappe_affiliate/doc_events/payment_entry.py
@@ -36,58 +36,68 @@ def record_referral(sales_invoice_doc, payment_entry_doc):
         }
     ).save()
 
-    record_referral_tiers(referral, sales_invoice_doc, payment_entry_doc.name)
+    if frappe.get_single_value("Affiliate Settings", "enable_tier_2"):
+        referral_2 = record_referral_tiers(
+            referral, sales_invoice_doc, payment_entry_doc.name, 2
+        )
+        if (
+            frappe.get_single_value("Affiliate Settings", "enable_tier_3")
+            and referral_2
+        ):
+            record_referral_tiers(
+                referral_2, sales_invoice_doc, payment_entry_doc.name, 3
+            )
 
 
-def record_referral_tiers(referral, invoice, payment_entry):
-    current_tier = 1
+def record_referral_tiers(referral, invoice, payment_entry, tier):
     sales_partner = referral.sales_partner
 
-    while sales_partner and current_tier < 2:
-        sales_partner_customer = frappe.db.get_value(
-            "Sales Partner", sales_partner, "custom_customer"
-        )
-        parent_sales_partner = frappe.db.get_value(
-            "Customer", sales_partner_customer, "default_sales_partner"
-        )
-        if not parent_sales_partner:
-            return
-        parent_banned = frappe.db.get_value(
-            "Sales Partner",
-            parent_sales_partner,
-            ["custom_banned", "custom_disabled"],
-            as_dict=True,
-        )
-        sales_partner_user = frappe.db.get_value(
-            "Sales Partner", parent_sales_partner, "custom_user"
-        )
-        if parent_banned.custom_disabled == 1 or parent_banned.custom_banned == 1:
-            continue
+    sales_partner_customer = frappe.db.get_value(
+        "Sales Partner", sales_partner, "custom_customer"
+    )
+    parent_sales_partner = frappe.db.get_value(
+        "Customer", sales_partner_customer, "default_sales_partner"
+    )
+    if not parent_sales_partner:
+        return
+    parent_banned = frappe.db.get_value(
+        "Sales Partner",
+        parent_sales_partner,
+        ["custom_banned", "custom_disabled"],
+        as_dict=True,
+    )
+    sales_partner_user = frappe.db.get_value(
+        "Sales Partner", parent_sales_partner, "custom_user"
+    )
+    if parent_banned.custom_disabled == 1 or parent_banned.custom_banned == 1:
+        return
 
-        affiliate_user_group = frappe.get_all(
-            "User Group Member", filters={"user": sales_partner_user}, pluck="parent"
-        )
+    affiliate_user_group = frappe.get_all(
+        "User Group Member", filters={"user": sales_partner_user}, pluck="parent"
+    )
 
-        if "Affiliate Tier {}".format(current_tier) not in affiliate_user_group:
-            sales_partner = parent_sales_partner
-            current_tier += 1
-            continue
+    tier_user_groups = frappe.get_all(
+        "Referral User Group",
+        filters={"parentfield": f"tier_{tier}_groups", "parent": "Affiliate Settings"},
+        fields=["user_group"],
+        pluck="user_group",
+    )
 
-        tier_referral_fee_rate = get_referral_fee_rule_for_tier(
-            invoice, "Affiliate Tier {}".format(current_tier)
-        )
+    if set(affiliate_user_group).isdisjoint(tier_user_groups):
+        return
 
-        frappe.get_doc(
-            {
-                "doctype": "Affiliate Referral",
-                "sales_partner": parent_sales_partner,
-                "payment_entry": payment_entry,
-                "amount": (referral.amount / 100) * tier_referral_fee_rate,
-                "date": referral.date,
-                "record_type": "commission",
-                "tier": current_tier,
-            }
-        ).save()
+    tier_referral_fee_rate = get_referral_fee_rule_for_tier(invoice, tier_user_groups)
 
-        current_tier += 1
-        sales_partner = parent_sales_partner
+    referral = frappe.get_doc(
+        {
+            "doctype": "Affiliate Referral",
+            "sales_partner": parent_sales_partner,
+            "payment_entry": payment_entry,
+            "amount": (referral.amount / 100) * tier_referral_fee_rate,
+            "date": referral.date,
+            "record_type": "commission",
+            "tier": tier - 1,
+        }
+    ).save()
+
+    return referral

--- a/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.json
+++ b/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.json
@@ -14,7 +14,14 @@
   "banner_and_text_link_route_path",
   "affiliate_redirect_url",
   "enable_keywords_support",
-  "banner_and_text_link"
+  "banner_and_text_link",
+  "affiliate_registration_email",
+  "intro_text_on_affiliate_info_page",
+  "referral_tiers_section",
+  "enable_tier_2",
+  "tier_2_groups",
+  "enable_tier_3",
+  "tier_3_groups"
  ],
  "fields": [
   {
@@ -81,13 +88,56 @@
    "in_list_view": 1,
    "label": "Affiliate Redirect URL",
    "reqd": 1
+  },
+  {
+   "fieldname": "affiliate_registration_email",
+   "fieldtype": "Link",
+   "label": "Affiliate Registration Email",
+   "options": "Email Template"
+  },
+  {
+   "fieldname": "intro_text_on_affiliate_info_page",
+   "fieldtype": "HTML Editor",
+   "label": "Intro Text on Affiliate Info Page"
+  },
+  {
+   "fieldname": "referral_tiers_section",
+   "fieldtype": "Section Break",
+   "label": "Referral Tiers"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_tier_2",
+   "fieldtype": "Check",
+   "label": "Enable Tier 2"
+  },
+  {
+   "depends_on": "eval:doc.enable_tier_2",
+   "fieldname": "tier_2_groups",
+   "fieldtype": "Table",
+   "label": "Tier 2 Groups",
+   "options": "Referral User Group"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.enable_tier_2",
+   "fieldname": "enable_tier_3",
+   "fieldtype": "Check",
+   "label": "Enable Tier 3"
+  },
+  {
+   "depends_on": "eval:doc.enable_tier_3",
+   "fieldname": "tier_3_groups",
+   "fieldtype": "Table",
+   "label": "Tier 3 Groups",
+   "options": "Referral User Group"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-23 21:44:10.978581",
+ "modified": "2025-11-20 04:38:03.172129",
  "modified_by": "Administrator",
  "module": "Frappe Affiliate",
  "name": "Affiliate Settings",

--- a/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.json
+++ b/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.json
@@ -15,8 +15,6 @@
   "affiliate_redirect_url",
   "enable_keywords_support",
   "banner_and_text_link",
-  "affiliate_registration_email",
-  "intro_text_on_affiliate_info_page",
   "referral_tiers_section",
   "enable_tier_2",
   "tier_2_groups",
@@ -88,17 +86,6 @@
    "in_list_view": 1,
    "label": "Affiliate Redirect URL",
    "reqd": 1
-  },
-  {
-   "fieldname": "affiliate_registration_email",
-   "fieldtype": "Link",
-   "label": "Affiliate Registration Email",
-   "options": "Email Template"
-  },
-  {
-   "fieldname": "intro_text_on_affiliate_info_page",
-   "fieldtype": "HTML Editor",
-   "label": "Intro Text on Affiliate Info Page"
   },
   {
    "fieldname": "referral_tiers_section",


### PR DESCRIPTION
## Description

Currently Affiliate tiers were always enabled and also weren't customisable. This PR adds relevant settings to enable and disable tiers alongside allowing admins to change which groups qualify as tier 2 and 3

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="1637" height="743" alt="image" src="https://github.com/user-attachments/assets/31ec2563-b9c6-452c-8f0b-58d3f29a2420" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)