### PR TITLE
Add filter for comment to referral fee rules

### DIFF
--- a/frappe_affiliate/api/referral_fee_rule.py
+++ b/frappe_affiliate/api/referral_fee_rule.py
@@ -21,7 +21,7 @@ def get_referral_fee_rules(
         order_by=order_by,
         limit_page_length=limit,
         limit_start=offset,
-        filters={"comment": ["like", comment_filter]} if comment_filter else None,
+        filters={"comment": ["like", f"%{comment_filter}%"]} if comment_filter else None,
     )
 
     result = {}

--- a/frappe_affiliate/api/referral_fee_rule.py
+++ b/frappe_affiliate/api/referral_fee_rule.py
@@ -4,7 +4,9 @@ from frappe_affiliate.api.sales_invoice import get_invoice_count
 
 
 @frappe.whitelist()
-def get_referral_fee_rules(limit=20, offset=0, order_by="priority asc"):
+def get_referral_fee_rules(
+    limit=20, offset=0, order_by="priority asc", comment_filter=None
+):
     referral_fee_rules_list = frappe.get_list(
         "Affiliate Referral Fee Rule",
         fields=[
@@ -19,6 +21,7 @@ def get_referral_fee_rules(limit=20, offset=0, order_by="priority asc"):
         order_by=order_by,
         limit_page_length=limit,
         limit_start=offset,
+        filters={"comment": ["like", comment_filter]} if comment_filter else None,
     )
 
     result = {}


### PR DESCRIPTION
## Description

This pull request updates the `get_referral_fee_rules` API to support filtering referral fee rules by a comment substring. This allows clients to retrieve only those rules whose comments match a specified pattern, improving the flexibility of the API.

Enhancements to referral fee rule filtering:

* The `get_referral_fee_rules` function in `frappe_affiliate/api/referral_fee_rule.py` now accepts an optional `comment_filter` parameter, enabling filtering of referral fee rules by comment content.
* The query inside `get_referral_fee_rules` applies a filter on the `comment` field using the provided `comment_filter` value, if specified.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #