### PR TITLE
Add API for click log retrieval

### DIFF
--- a/frappe_affiliate/api/affiliate_statistics.py
+++ b/frappe_affiliate/api/affiliate_statistics.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.utils import (
     add_months,
     cint,
@@ -141,9 +142,7 @@ def get_period_statistics(start_date, end_date):
 
 
 @frappe.whitelist(methods=["GET"])
-def get_click_log_for_statistic(
-    date: str | None = None, by_month=1, start: int = 0, limit: int = 20
-) -> list:
+def get_click_log_for_statistic(date=None, by_month=1, start=0, limit=20) -> dict:
     """
     Get click log entries for a specific date
 
@@ -170,16 +169,25 @@ def get_click_log_for_statistic(
             "start": 0,
             "limit": 20
         }
-    },
+    }
     """
     by_month = cint(by_month)
+    limit = max(1, cint(limit))
+    start = max(0, cint(start))
 
     sales_partner = frappe.db.get_value(
         "Sales Partner", {"custom_user": frappe.session.user}, "name"
     )
 
+    result = {
+        "click_logs": [],
+        "total": 0,
+        "start": start,
+        "limit": limit,
+    }
+
     if not sales_partner:
-        return []
+        return result
 
     try:
         if by_month:
@@ -188,8 +196,8 @@ def get_click_log_for_statistic(
             end_date = get_last_day(start_date)
         else:
             start_date = end_date = getdate(date)
-    except (ValueError, AttributeError):
-        return {"error": "Invalid date format."}
+    except (ValueError, AttributeError, TypeError):
+        frappe.throw(_("Invalid date format."))
 
     start_datetime = frappe.utils.get_datetime(start_date)
     end_datetime = frappe.utils.get_datetime(end_date).replace(
@@ -215,9 +223,7 @@ def get_click_log_for_statistic(
         filters=filters,
     )
 
-    return {
-        "click_logs": click_logs,
-        "total": total_clicks,
-        "start": start,
-        "limit": limit,
-    }
+    result["click_logs"] = click_logs
+    result["total"] = total_clicks
+
+    return result

--- a/frappe_affiliate/api/affiliate_statistics.py
+++ b/frappe_affiliate/api/affiliate_statistics.py
@@ -138,3 +138,46 @@ def get_period_statistics(start_date, end_date):
         "clicks": clicks_count or 0,
         "unique_clicks": len(unique_clicks_count) or 0,
     }
+
+
+@frappe.whitelist(methods=["GET"])
+def get_click_log_for_statistic(date: str | None = None, by_month=1) -> list:
+    """
+    Get click log entries for a specific date
+    If by_month is True, date is expected in 'YYYY-MM' format, else 'YYYY-MM-DD' format
+    """
+    by_month = cint(by_month)
+
+    sales_partner = frappe.db.get_value(
+        "Sales Partner", {"custom_user": frappe.session.user}, "name"
+    )
+
+    if not sales_partner:
+        return []
+
+    try:
+        if by_month:
+            modified_date = date + "-01"
+            start_date = get_first_day(modified_date)
+            end_date = get_last_day(start_date)
+        else:
+            start_date = end_date = getdate(date)
+    except (ValueError, AttributeError):
+        return {"error": "Invalid date format."}
+
+    start_datetime = frappe.utils.get_datetime(start_date)
+    end_datetime = frappe.utils.get_datetime(end_date).replace(
+        hour=23, minute=59, second=59
+    )
+
+    click_logs = frappe.get_all(
+        "Affiliate Click Log",
+        filters={
+            "sales_partner": sales_partner,
+            "time": ["between", [start_datetime, end_datetime]],
+        },
+        order_by="time desc",
+        fields=["time", "referrer"],
+    )
+
+    return click_logs

--- a/frappe_affiliate/api/affiliate_statistics.py
+++ b/frappe_affiliate/api/affiliate_statistics.py
@@ -141,10 +141,36 @@ def get_period_statistics(start_date, end_date):
 
 
 @frappe.whitelist(methods=["GET"])
-def get_click_log_for_statistic(date: str | None = None, by_month=1) -> list:
+def get_click_log_for_statistic(
+    date: str | None = None, by_month=1, start: int = 0, limit: int = 20
+) -> list:
     """
     Get click log entries for a specific date
-    If by_month is True, date is expected in 'YYYY-MM' format, else 'YYYY-MM-DD' format
+
+    Params:
+    - date (str): The date or month for which to retrieve click logs.
+    - by_month (int): If 1, date is treated as month (YYYY-MM); if 0, as specific date (YYYY-MM-DD).
+    - start (int): The starting index for pagination.
+    - limit (int): The number of records to retrieve.
+
+    Response:
+        {
+        "message": {
+            "click_logs": [
+                {
+                    "time": "2025-11-25 10:52:27",
+                    "referrer": null
+                },
+                {
+                    "time": "2025-11-25 10:52:27",
+                    "referrer": "https://www.google.com"
+                }
+            ],
+            "total": 2,
+            "start": 0,
+            "limit": 20
+        }
+    },
     """
     by_month = cint(by_month)
 
@@ -170,14 +196,28 @@ def get_click_log_for_statistic(date: str | None = None, by_month=1) -> list:
         hour=23, minute=59, second=59
     )
 
+    filters = {
+        "sales_partner": sales_partner,
+        "time": ["between", [start_datetime, end_datetime]],
+    }
+
     click_logs = frappe.get_all(
         "Affiliate Click Log",
-        filters={
-            "sales_partner": sales_partner,
-            "time": ["between", [start_datetime, end_datetime]],
-        },
+        filters=filters,
         order_by="time desc",
         fields=["time", "referrer"],
+        start=start,
+        limit=limit,
     )
 
-    return click_logs
+    total_clicks = frappe.db.count(
+        "Affiliate Click Log",
+        filters=filters,
+    )
+
+    return {
+        "click_logs": click_logs,
+        "total": total_clicks,
+        "start": start,
+        "limit": limit,
+    }


### PR DESCRIPTION
## Description

This pull request introduces a new API endpoint to retrieve click log entries for affiliate statistics, allowing users to filter by date or month and supports pagination. The main addition is the `get_click_log_for_statistic` function, which fetches click logs for the authenticated sales partner.

**New API endpoint for click log retrieval:**

* Added `get_click_log_for_statistic` function to `frappe_affiliate/api/affiliate_statistics.py`, enabling retrieval of click logs by date or month, with pagination and total count support.
* The endpoint validates the user's sales partner status and handles date formatting, returning an error if the date format is invalid.
* Results include log entries with `time` and `referrer`, as well as metadata (`total`, `start`, `limit`) for pagination.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)