### PR TITLE
Fix coupon validity check failing due to string and int matching

### DIFF
--- a/frappe_affiliate/utils/coupon_code.py
+++ b/frappe_affiliate/utils/coupon_code.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe import _ as translate
-from frappe.utils import cint, getdate, nowdate
+from frappe.utils import getdate, nowdate
 
 
 def update_coupon_code_count(coupon_code_doc, transaction_type):
@@ -99,7 +99,6 @@ def check_item_in_coupon_batch(item_list, coupon_batch):
         pluck="item_code",
     )
     if apply_on_specific and apply_on_specific != []:
-        apply_on_specific = [cint(item_code) for item_code in apply_on_specific]
         applies = set(item_list).issubset(apply_on_specific)
         if not applies:
             return False


### PR DESCRIPTION
## Description

This PR fixes issues with coupon validity check caused due to matching string with int. Now it only performs string check.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)