### PR TITLE
Add referral void on invoice return

### DIFF
--- a/frappe_affiliate/doc_events/sales_invoice.py
+++ b/frappe_affiliate/doc_events/sales_invoice.py
@@ -40,3 +40,33 @@ def validate(doc, method=None):
             return
         doc.commission_rate = apply_referral_fee_rules(doc)
         doc.calculate_commission()
+
+
+def on_submit(doc, method=None):
+    if doc.is_return:
+        frappe.enqueue(void_referral_fee, doc=doc, timeout=3600)
+
+
+def void_referral_fee(doc):
+    returned_invoice = doc.return_against
+    payment_entry_ref = frappe.get_all(
+        "Payment Entry Reference",
+        fields=["parent"],
+        filters={
+            "reference_doctype": "Sales Invoice",
+            "reference_name": returned_invoice,
+        },
+    )
+    for ref in payment_entry_ref:
+        affiliate_fee = frappe.get_all(
+            "Affiliate Referral",
+            filters={"payment_entry": ref.parent, "tier": 0, "record_type": "referral"},
+            fields=["name"],
+        )
+        for fee in affiliate_fee:
+            frappe.set_value(
+                "Affiliate Referral",
+                fee.name,
+                "void",
+                1,
+            )

--- a/frappe_affiliate/hooks.py
+++ b/frappe_affiliate/hooks.py
@@ -145,6 +145,7 @@ doc_events = {
     },
     "Sales Invoice": {
         "validate": ["frappe_affiliate.doc_events.sales_invoice.validate"],
+        "on_submit": ["frappe_affiliate.doc_events.sales_invoice.on_submit"],
     },
     "Payment Entry": {
         "on_submit": ["frappe_affiliate.doc_events.payment_entry.on_submit"],


### PR DESCRIPTION
## Description

Currently Affiliate Referral do not get void on return. This adds a doc event to void related referrals on marking a sales invoice as return.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #