### PR TITLE
Add before insert hook to subscription

### DIFF
--- a/frappe_affiliate/doc_events/subscription.py
+++ b/frappe_affiliate/doc_events/subscription.py
@@ -29,3 +29,36 @@ def validate(doc, method=None):
                         "Cannot use coupon code assigned to your own affiliate account."
                     )
                 )
+
+
+def before_insert(doc, method=None):
+    if frappe.flags.in_migrate:
+        return
+
+    linked_affiliate = None
+
+    if doc.party_type != "Customer":
+        return
+
+    if doc.custom_coupon_code:
+        coupon_code_doc = frappe.get_doc("Coupon Code", doc.custom_coupon_code)
+        if coupon_code_doc.customer and coupon_code_doc.customer != doc.party:
+            frappe.throw(translate("This coupon code is not valid for this user"))
+        if coupon_code_doc.custom_sales_partner:
+            linked_affiliate = coupon_code_doc.custom_sales_partner
+    else:
+        customer_affiliate = frappe.db.get_value(
+            "Customer", doc.party, "default_sales_partner"
+        )
+        if customer_affiliate and customer_affiliate != "":
+            linked_affiliate = customer_affiliate
+
+    if linked_affiliate:
+        affiliate_banned = frappe.db.get_value(
+            "Sales Partner",
+            linked_affiliate,
+            ["custom_banned", "custom_disabled"],
+            as_dict=True,
+        )
+        if not affiliate_banned.custom_disabled and not affiliate_banned.custom_banned:
+            doc.custom_affiliate = linked_affiliate


### PR DESCRIPTION
## Description

This pull request adds a new `before_insert` hook to the `frappe_affiliate/doc_events/subscription.py` file to improve affiliate assignment logic when a subscription is created. The new logic ensures that the correct affiliate is linked to the subscription based on the coupon code or the customer's default affiliate, and validates that the affiliate is neither banned nor disabled before assignment.

Affiliate assignment and validation improvements:

* Added a `before_insert` function that determines the appropriate affiliate to link to the subscription, prioritizing the affiliate from a valid coupon code or the customer's default affiliate, and ensures the affiliate is not banned or disabled before assignment.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #