### PR TITLE
Treat expired and disabled coupons as same

### DIFF
--- a/frappe_affiliate/utils/coupon_code.py
+++ b/frappe_affiliate/utils/coupon_code.py
@@ -50,25 +50,26 @@ def validate_coupon_code(
             return False
         coupon_code_doc = frappe.get_doc("Coupon Code", coupon_doc_name)
 
-    if is_new_subscription and coupon_code_doc.custom_disable:
-        return False
-    elif coupon_code_doc.valid_from and getdate(coupon_code_doc.valid_from) > getdate(
-        nowdate()
-    ):
-        return False
-    elif coupon_code_doc.valid_upto and getdate(coupon_code_doc.valid_upto) < getdate(
-        nowdate()
-    ):
-        return False
-    elif (
+    if is_new_subscription:
+        if coupon_code_doc.custom_disable:
+            return False
+        elif coupon_code_doc.valid_from and getdate(
+            coupon_code_doc.valid_from
+        ) > getdate(nowdate()):
+            return False
+        elif coupon_code_doc.valid_upto and getdate(
+            coupon_code_doc.valid_upto
+        ) < getdate(nowdate()):
+            return False
+        elif (
+            coupon_code_doc.custom_subscription_maximum_use
+            and coupon_code_doc.custom_subscription_used_count
+            >= coupon_code_doc.custom_subscription_maximum_use
+        ):
+            return False
+    if (
         coupon_code_doc.maximum_use
         and coupon_code_doc.used >= coupon_code_doc.maximum_use
-    ):
-        return False
-    elif (
-        coupon_code_doc.custom_subscription_maximum_use
-        and coupon_code_doc.custom_subscription_used_count
-        >= coupon_code_doc.custom_subscription_maximum_use
     ):
         return False
 


### PR DESCRIPTION
## Description

This pull request refactors the logic for validating coupon codes in the `validate_coupon_code` function, making the checks for new subscriptions more explicit and improving the clarity of the validation flow. The main focus is on restructuring the conditional checks to ensure that coupon restrictions are applied in the correct order.

Coupon code validation logic improvements:

* Refactored the conditional structure inside `validate_coupon_code` to nest checks for `custom_disable`, `valid_from`, `valid_upto`, and `custom_subscription_maximum_use` under the `is_new_subscription` condition, clarifying their application only to new subscriptions.
* Moved the check for `maximum_use` outside the new subscription block, ensuring that the maximum use restriction is enforced for all cases, not just new subscriptions.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)