### PR TITLE
Add logic to create refund entries

### DIFF
--- a/frappe_affiliate/doc_events/sales_invoice.py
+++ b/frappe_affiliate/doc_events/sales_invoice.py
@@ -32,7 +32,15 @@ def on_submit(doc, method=None):
     if not return_invoice:
         return
 
-    payment_entries = frappe.get_all(
+    original_invoice_value = frappe.get_value("Sales Invoice", return_invoice, "total")
+    return_invoice_value = doc.total
+
+    if return_invoice_value > 0:
+        return
+
+    percentage_deduction = abs(return_invoice_value) / original_invoice_value
+
+    payment_entries = frappe.get_list(
         "Payment Entry Reference",
         filters={"reference_name": return_invoice},
         fields=["parent"],
@@ -40,13 +48,37 @@ def on_submit(doc, method=None):
         group_by="parent",
     )
 
-    referrals = frappe.get_all(
+    referrals = frappe.get_list(
         "Affiliate Referral",
-        filters={"payment_entry": ["in", payment_entries], "tier": 0},
+        filters={
+            "payment_entry": ["in", payment_entries],
+            "void": 0,
+            "record_type": "referral",
+        },
         fields=["name"],
         pluck="name",
         distinct=True,
     )
 
     for referral in referrals:
-        frappe.set_value("Affiliate Referral", referral, "void", 1)
+        frappe.db.set_value(
+            "Affiliate Referral", referral, "void", 1
+        )  # Set through frappe.db to avoid triggering events
+        voided_referral = frappe.get_doc("Affiliate Referral", referral)
+        void_referral_doc = frappe.new_doc("Affiliate Referral")
+
+        adjusted_amount = voided_referral.amount * percentage_deduction
+
+        set_values = {
+            "sales_partner": voided_referral.sales_partner,
+            "payment_entry": voided_referral.payment_entry,
+            "amount": adjusted_amount,
+            "record_type": "void",
+            "tier": 0,
+            "void": 0,
+            "void_affiliate_referral": voided_referral.name,
+            "date": frappe.utils.nowdate(),
+        }
+
+        void_referral_doc.update(set_values)
+        void_referral_doc.deferred_insert()


### PR DESCRIPTION
## Description

This pull request refines the handling of affiliate referrals when a return sales invoice is submitted. The main improvements ensure that voided referrals are accurately recorded and that new void referral records are created with correctly adjusted amounts based on the return value.

**Affiliate referral voiding and adjustment:**

* Calculates the percentage deduction for the return invoice and applies it to the referral amount to ensure proportional adjustment.
* Updates the logic to only process return invoices with a negative total, preventing unnecessary operations.
* Filters referrals more accurately by including only non-voided, tier 0, and "referral" type records.
* Sets the `void` field directly in the database to avoid triggering document events and creates a new "void" referral record with the adjusted amount, linking it to the original referral.
* Switches from `frappe.get_all` to `frappe.get_list` for improved query clarity and consistency.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)