### PR TITLE
Add validations to coupon batch and referral rules

### DIFF
--- a/frappe_affiliate/frappe_affiliate/doctype/affiliate_referral_fee_rule/affiliate_referral_fee_rule.py
+++ b/frappe_affiliate/frappe_affiliate/doctype/affiliate_referral_fee_rule/affiliate_referral_fee_rule.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import flt
 
 
 class AffiliateReferralFeeRule(Document):
@@ -33,6 +34,8 @@ class AffiliateReferralFeeRule(Document):
     # end: auto-generated types
 
     def validate(self):
+        self.first_referral_rate = flt(self.first_referral_rate)
+        self.subsequent_referral_rate = flt(self.subsequent_referral_rate)
         if self.first_referral_rate > 100 or self.subsequent_referral_rate > 100:
             frappe.throw(_("Referral rates must be between 0 and 100."))
 

--- a/frappe_affiliate/frappe_affiliate/doctype/coupon_batch/coupon_batch.py
+++ b/frappe_affiliate/frappe_affiliate/doctype/coupon_batch/coupon_batch.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -46,6 +47,13 @@ class CouponBatch(Document):
         if not frappe.flags.in_migration:
             if self.coupon_type == "Single" and not self.coupon_code:
                 self.coupon_code = frappe.generate_hash()[:10].upper()
+            elif self.coupon_type == "Batch of Random Coupon Codes":
+                if not self.coupons_count or not self.code_length:
+                    frappe.throw(
+                        _(
+                            "For batch coupon generation, both Coupons Count and Code Length are required."
+                        )
+                    )
 
     def on_update(self):
         if not frappe.flags.in_migration:


### PR DESCRIPTION
## Description

This pull request introduces improvements to data validation and input handling in both the `AffiliateReferralFeeRule` and `CouponBatch` doctypes. The main focus is on ensuring proper data types and enforcing required fields for coupon generation.

**Validation and Input Handling Improvements:**

* In `affiliate_referral_fee_rule.py`, referral rates are now explicitly converted to floats using `flt` before validation to prevent type errors and ensure accurate comparison. [[1]](diffhunk://#diff-88abe6b68b47b18b2ef1ee1768ae59f8523745253a1d356e3eb4944310140da4R7) [[2]](diffhunk://#diff-88abe6b68b47b18b2ef1ee1768ae59f8523745253a1d356e3eb4944310140da4R37-R38)
* In `coupon_batch.py`, added validation to require both `coupons_count` and `code_length` fields when generating a batch of random coupon codes, ensuring all necessary input is provided.

**Imports and Localization:**

* Added the import of `_` from `frappe` in `coupon_batch.py` to support translation/localization for error messages.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #