### PR TITLE
Make discounts non-negative entry

### DIFF
--- a/frappe_affiliate/frappe_affiliate/doctype/affiliate_referral_fee_rule/affiliate_referral_fee_rule.json
+++ b/frappe_affiliate/frappe_affiliate/doctype/affiliate_referral_fee_rule/affiliate_referral_fee_rule.json
@@ -67,6 +67,7 @@
    "fieldtype": "Percent",
    "in_list_view": 1,
    "label": "First Referral Rate",
+   "non_negative": 1,
    "reqd": 1
   },
   {
@@ -74,13 +75,14 @@
    "fieldtype": "Percent",
    "in_list_view": 1,
    "label": "Subsequent Referral Rate",
+   "non_negative": 1,
    "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-14 08:21:32.119408",
+ "modified": "2026-03-03 00:34:58.527008",
  "modified_by": "Administrator",
  "module": "Frappe Affiliate",
  "name": "Affiliate Referral Fee Rule",

--- a/frappe_affiliate/frappe_affiliate/doctype/coupon_batch/coupon_batch.json
+++ b/frappe_affiliate/frappe_affiliate/doctype/coupon_batch/coupon_batch.json
@@ -184,6 +184,7 @@
    "fieldname": "discount",
    "fieldtype": "Float",
    "label": "Discount",
+   "non_negative": 1,
    "reqd": 1
   },
   {
@@ -200,7 +201,8 @@
    "fieldname": "recurring_discount",
    "fieldtype": "Float",
    "label": "Recurring Discount",
-   "mandatory_depends_on": "eval:doc.apply_to_recurring"
+   "mandatory_depends_on": "eval:doc.apply_to_recurring",
+   "non_negative": 1
   },
   {
    "fieldname": "column_break_sohp",
@@ -220,7 +222,7 @@
   }
  ],
  "links": [],
- "modified": "2026-01-18 21:29:14.863543",
+ "modified": "2026-03-03 00:37:13.174315",
  "modified_by": "Administrator",
  "module": "Frappe Affiliate",
  "name": "Coupon Batch",


### PR DESCRIPTION
## Description

This pull request updates the validation rules for several fields in the `Affiliate Referral Fee Rule` and `Coupon Batch` doctypes to ensure that percentage and discount values cannot be negative. This helps prevent invalid data entry and enforces more robust data integrity.

Validation improvements for non-negative values:

* Added the `non_negative` constraint to the `first_referral_rate` and `subsequent_referral_rate` percent fields in `affiliate_referral_fee_rule.json` to prevent negative referral rates.
* Added the `non_negative` constraint to the `discount` and `recurring_discount` float fields in `coupon_batch.json` to ensure discounts cannot be negative. [[1]](diffhunk://#diff-6c84107494d549ac6f50eedc26e4b012d0cf09837221ba96a96123334c447572R187) [[2]](diffhunk://#diff-6c84107494d549ac6f50eedc26e4b012d0cf09837221ba96a96123334c447572L203-R205)

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #