### PR TITLE
Optimize referral void to prevent timeout during refund submission

### DIFF
--- a/frappe_affiliate/doc_events/sales_invoice.py
+++ b/frappe_affiliate/doc_events/sales_invoice.py
@@ -24,61 +24,70 @@ def validate(doc, method=None):
 
 
 def on_submit(doc, method=None):
-    is_return = doc.get("is_return", 0)
-    if not is_return:
+    if not doc.get("is_return"):
         return
 
-    return_invoice = doc.get("return_against", None)
+    return_invoice = doc.get("return_against")
     if not return_invoice:
         return
 
-    original_invoice_value = frappe.get_value("Sales Invoice", return_invoice, "total")
+    original_invoice_value = frappe.db.get_value(
+        "Sales Invoice", return_invoice, "total"
+    )
     return_invoice_value = doc.total
 
-    if return_invoice_value > 0:
+    if not original_invoice_value or return_invoice_value >= 0:
         return
 
     percentage_deduction = abs(return_invoice_value) / original_invoice_value
 
-    payment_entries = frappe.get_list(
+    payment_entries = frappe.get_all(
         "Payment Entry Reference",
         filters={"reference_name": return_invoice},
-        fields=["parent"],
         pluck="parent",
-        group_by="parent",
+        distinct=True,
     )
 
-    referrals = frappe.get_list(
+    if not payment_entries:
+        return
+
+    referrals = frappe.get_all(
         "Affiliate Referral",
         filters={
             "payment_entry": ["in", payment_entries],
             "void": 0,
             "record_type": "referral",
         },
-        fields=["name"],
-        pluck="name",
-        distinct=True,
+        fields=["name", "amount", "sales_partner", "payment_entry"],
     )
 
-    for referral in referrals:
-        frappe.db.set_value(
-            "Affiliate Referral", referral, "void", 1
-        )  # Set through frappe.db to avoid triggering events
-        voided_referral = frappe.get_doc("Affiliate Referral", referral)
+    if not referrals:
+        return
+
+    referral_names = [ref.name for ref in referrals]
+
+    frappe.db.set_value(
+        "Affiliate Referral", {"name": ["in", referral_names]}, "void", 1
+    )
+
+    current_date = frappe.utils.nowdate()
+
+    for ref in referrals:
+        adjusted_amount = ref.amount * percentage_deduction
+
         void_referral_doc = frappe.new_doc("Affiliate Referral")
 
-        adjusted_amount = voided_referral.amount * percentage_deduction
+        void_referral_doc.update(
+            {
+                "sales_partner": ref.sales_partner,
+                "payment_entry": ref.payment_entry,
+                "amount": adjusted_amount,
+                "record_type": "void",
+                "tier": 0,
+                "void": 0,
+                "void_affiliate_referral": ref.name,
+                "date": current_date,
+            }
+        )
 
-        set_values = {
-            "sales_partner": voided_referral.sales_partner,
-            "payment_entry": voided_referral.payment_entry,
-            "amount": adjusted_amount,
-            "record_type": "void",
-            "tier": 0,
-            "void": 0,
-            "void_affiliate_referral": voided_referral.name,
-            "date": frappe.utils.nowdate(),
-        }
-
-        void_referral_doc.update(set_values)
         void_referral_doc.deferred_insert()


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR optimizes the `on_submit` event for Sales Invoices, specifically focusing on the logic that voids `Affiliate Referral` records when a Sales Invoice is returned (refunded). 

Previously, the code executed N+1 database queries by fetching each `Affiliate Referral` document inside a loop and updating their `void` status one by one. This PR refactors the logic to bulk-fetch necessary fields, bulk-update the statuses, and eliminate unnecessary database calls, significantly improving performance for invoices with multiple referrals.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
* **N+1 Query Elimination:** Modified the `frappe.get_all` call for referrals to fetch all required fields (`name`, `amount`, `sales_partner`, `payment_entry`) upfront. This removes the need to call `frappe.get_doc()` repeatedly inside the loop.
* **Bulk Database Update:** Replaced the iterative `frappe.db.set_value` calls with a single bulk update using an `IN` condition (`{"name": ["in", referral_names]}`) to mark all associated referrals as void in one query.
* **Defensive Programming:** Added a safeguard (`if not original_invoice_value or return_invoice_value >= 0`) to prevent potential `ZeroDivisionError` exceptions and ensure we only process valid partial or full returns. Added early exits if no payment entries or referrals are found.
* **`get_all` vs `get_list`:** Swapped `frappe.get_list` for `frappe.get_all` to bypass unnecessary user permission checks, which is standard best practice for system-level background doc events, and used `distinct=True` for cleaner querying.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

1. **Setup:** * Identify or create an original `Sales Invoice` that was paid and generated at least one `Affiliate Referral` record.
2. **Process Return:**
   * Create a "Sales Return" (Credit Note) against the original invoice for either a partial amount or the full amount.
   * Submit the Return Sales Invoice.
3. **Verify Referrals:**
   * Go to the `Affiliate Referral` list.
   * **Verify:** The original referral record(s) linked to the invoice should now have the `void` checkbox checked.
   * **Verify:** New `Affiliate Referral` record(s) should be created with `record_type` set to "void". 
   * **Verify:** The `amount` on the new void record should accurately reflect the percentage of the refund (e.g., a 50% refund should generate a void referral for 50% of the original commission).

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->
N/A

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
N/A

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)