### PR TITLE
Add helper text to Affiliate Settings fields

### DIFF
--- a/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.json
+++ b/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.json
@@ -25,18 +25,21 @@
  ],
  "fields": [
   {
+   "description": "Days to store cookies about referred affiliate",
    "fieldname": "cookie_timeout",
    "fieldtype": "Int",
    "label": "Cookie Timeout",
    "non_negative": 1
   },
   {
+   "description": "Minimal commission amount earned by affiliate to include it to payout report",
    "fieldname": "minimum_payout",
    "fieldtype": "Int",
    "label": "Minimum Payout",
    "non_negative": 1
   },
   {
+   "description": "Number of days that should go through before commission is included to payout report",
    "fieldname": "delay_payout_days",
    "fieldtype": "Int",
    "label": "Delay Payout (days)",
@@ -44,6 +47,7 @@
   },
   {
    "default": "0",
+   "description": "Enable ability to track traffic sources adding keywords to url",
    "fieldname": "enable_keywords_support",
    "fieldtype": "Check",
    "label": "Enable Keywords Support"
@@ -138,7 +142,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-18 12:39:53.263168",
+ "modified": "2026-03-11 10:51:00.801554",
  "modified_by": "Administrator",
  "module": "Frappe Affiliate",
  "name": "Affiliate Settings",

--- a/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.py
+++ b/frappe_affiliate/frappe_affiliate/doctype/affiliate_settings/affiliate_settings.py
@@ -13,13 +13,8 @@ class AffiliateSettings(Document):
 
     if TYPE_CHECKING:
         from frappe.types import DF
-
-        from frappe_affiliate.frappe_affiliate.doctype.affiliate_banner_and_text_link.affiliate_banner_and_text_link import (
-            AffiliateBannerandTextLink,
-        )
-        from frappe_affiliate.frappe_affiliate.doctype.referral_user_group.referral_user_group import (
-            ReferralUserGroup,
-        )
+        from frappe_affiliate.frappe_affiliate.doctype.affiliate_banner_and_text_link.affiliate_banner_and_text_link import AffiliateBannerandTextLink
+        from frappe_affiliate.frappe_affiliate.doctype.referral_user_group.referral_user_group import ReferralUserGroup
 
         affiliate_redirect_url: DF.Data
         affiliate_registration_email: DF.Link | None


### PR DESCRIPTION
## Description

This PR:
- Add helper text to `Affiliate Settings` fields


## Testing Instructions

- Test Helper text on `/admin/affiliates/settings` page

## Additional Information:

> None

## Screenshot/Screencast




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
