### PR TITLE
Add null guard for updating coupon code count on first subscription

### DIFF
--- a/frappe_affiliate/doc_events/payment_entry.py
+++ b/frappe_affiliate/doc_events/payment_entry.py
@@ -25,6 +25,8 @@ def on_submit(doc, method=None):
     ):
         record_referral(sales_invoice_doc, doc)
 
+    if not sales_invoice_doc.custom_apex_public_id:
+        return
     sales_invoice_count = sales_invoice_doc.custom_apex_public_id.split("/")[-1]
     if sales_invoice_count == "1" and sales_invoice_doc.coupon_code:
         coupon_code_doc = frappe.get_doc("Coupon Code", sales_invoice_doc.coupon_code)


### PR DESCRIPTION
## Description

This PR fixes a potential crash during the submission of a `Payment Entry`. 

Previously, the system assumed that every linked `Sales Invoice` would have a `custom_apex_public_id` and immediately called `.split("/")` on it to check if it was the first payment in a subscription cycle (to update the coupon code usage count). If an invoice lacked this ID, it resulted in an `AttributeError`, blocking the payment submission. This PR adds a simple null guard to exit the coupon tracking logic safely if the ID is missing.

## Relevant Technical Choices

* **Null Guard (`payment_entry.py`)**: Added an early return (`if not sales_invoice_doc.custom_apex_public_id: return`) right before the string splitting logic in the `on_submit` event. This safely bypasses the coupon increment logic for non-subscription or malformed invoices.

## Testing Instructions

1. **Test Standard Payment:**
   * Find or create a standard `Sales Invoice` that does *not* have a `custom_apex_public_id` populated.
   * Create a `Payment Entry` against this invoice.
   * Click **Submit**.
   * **Verify:** The Payment Entry should submit successfully without throwing a server error.

2. **Test Subscription Payment (Regression):**
   * Process a payment for a standard subscription invoice that *does* have a `custom_apex_public_id` (ending in `/1`) and a linked coupon code.
   * **Verify:** The payment submits successfully and the linked `Coupon Code` usage count increments as expected.

## Additional Information:

N/A

## Screenshot/Screencast

N/A

## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)