### PR TITLE
perf: optimise affiliate statistics and subtract void referrals

### DIFF
--- a/frappe_affiliate/api/affiliate_advanced_statistics.py
+++ b/frappe_affiliate/api/affiliate_advanced_statistics.py
@@ -1,15 +1,17 @@
-from collections import defaultdict
-
 import frappe
 from frappe.utils import (
     add_days,
     add_months,
     date_diff,
     formatdate,
-    get_datetime,
     get_first_day,
     get_last_day,
     getdate,
+)
+
+from frappe_affiliate.utils.statistics import (
+    aggregate_period,
+    fetch_referral_and_click_buckets,
 )
 
 
@@ -332,10 +334,9 @@ def get_period_dates(period, start_date=None, end_date=None, affiliate_join=None
 def get_grouped_statistics(start_date, end_date, grouping, user=None):
     """Get statistics grouped by the specified grouping (Day, Week, Month, Quarter, Year).
 
-    Uses batch queries to avoid the N+1 query problem for large date ranges: all referral
-    and click data for the full range is fetched once and then aggregated in Python per period.
+    One bulk fetch for the full range (fetch_referral_and_click_buckets), then each period
+    is aggregated in memory via aggregate_period — avoiding the per-period N+1 queries.
     """
-    # Resolve Sales Partner once — avoids one redundant DB round-trip per period.
     sales_partner = frappe.db.get_value(
         "Sales Partner", {"custom_user": user or frappe.session.user}, "name"
     )
@@ -343,44 +344,9 @@ def get_grouped_statistics(start_date, end_date, grouping, user=None):
     if not sales_partner:
         return []
 
-    end_datetime = get_datetime(end_date).replace(hour=23, minute=59, second=59)
-
-    # Single bulk fetch for all referrals in the full date range.
-    all_referrals = frappe.get_all(
-        "Affiliate Referral",
-        filters={
-            "sales_partner": sales_partner,
-            "record_type": ["in", ["referral", "void"]],
-            "date": ["between", [start_date, end_date]],
-            "void": 0,
-        },
-        fields=["date", "amount", "record_type"],
+    referrals_by_date, clicks_by_date = fetch_referral_and_click_buckets(
+        sales_partner, start_date, end_date
     )
-
-    # Single bulk fetch for all clicks in the full date range.
-    all_clicks = frappe.get_all(
-        "Affiliate Click Log",
-        filters={
-            "sales_partner": sales_partner,
-            "time": ["between", [get_datetime(start_date), end_datetime]],
-        },
-        fields=["time", "remote_address"],
-    )
-
-    # Pre-bucket referrals by date to avoid O(periods × rows) scans in the loop.
-    # Structure: {date: {"referral": [amounts], "void": [amounts]}}
-    referrals_by_date = defaultdict(lambda: {"referral": [], "void": []})
-    for r in all_referrals:
-        referrals_by_date[r.date][r.record_type].append(r.amount)
-
-    # Pre-bucket click remote_addresses by calendar date.
-    # Unique-click counting per period unions all IPs across all dates in the period,
-    # giving correct cross-day deduplication (e.g. same IP on Mon + Wed = 1 unique for
-    # the week). A day-level SQL GROUP BY approach would overcount in multi-day periods.
-    # Structure: {date: [remote_address, ...]}
-    clicks_by_date = defaultdict(list)
-    for c in all_clicks:
-        clicks_by_date[getdate(c.time)].append(c.remote_address)
 
     data = []
     current_date = start_date
@@ -428,37 +394,17 @@ def get_grouped_statistics(start_date, end_date, grouping, user=None):
         if period_start > end_date:
             break
 
-        # Aggregate from pre-bucketed dicts — O(dates_in_period) per iteration,
-        # not O(all_rows) as it was with the previous list-comprehension scans.
-        dates_in_period = [
-            d for d in referrals_by_date if period_start <= d <= period_end
-        ]
-        sales_amounts = [
-            a for d in dates_in_period for a in referrals_by_date[d]["referral"]
-        ]
-        void_amounts = [
-            a for d in dates_in_period for a in referrals_by_date[d]["void"]
-        ]
-
-        click_dates_in_period = [
-            d for d in clicks_by_date if period_start <= d <= period_end
-        ]
-        period_total_clicks = sum(len(clicks_by_date[d]) for d in click_dates_in_period)
-        # Union all IPs across the period to get true cross-day unique visitors.
-        period_unique_ips = len(
-            {ip for d in click_dates_in_period for ip in clicks_by_date[d]}
+        stats = aggregate_period(
+            referrals_by_date, clicks_by_date, period_start, period_end
         )
-
-        stats = {
-            "transactions": len(sales_amounts),
-            "referral_fee_earned": sum(sales_amounts) - sum(void_amounts),
-            "clicks": period_total_clicks,
-            "unique_clicks": period_unique_ips,
-            "period": period_key,
-            "period_label": period_label,
-            "period_start": formatdate(period_start, "yyyy-MM-dd"),
-            "period_end": formatdate(period_end, "yyyy-MM-dd"),
-        }
+        stats.update(
+            {
+                "period": period_key,
+                "period_label": period_label,
+                "period_start": formatdate(period_start, "yyyy-MM-dd"),
+                "period_end": formatdate(period_end, "yyyy-MM-dd"),
+            }
+        )
 
         data.append(stats)
         current_date = next_date
@@ -484,54 +430,9 @@ def get_period_statistics(start_date, end_date, user=None):
             "unique_clicks": 0,
         }
 
-    start_datetime = get_datetime(start_date)
-    end_datetime = get_datetime(end_date).replace(hour=23, minute=59, second=59)
-
-    sales = frappe.get_all(
-        "Affiliate Referral",
-        filters={
-            "sales_partner": sales_partner,
-            "record_type": "referral",
-            "date": ["between", [start_datetime, end_datetime]],
-            "void": 0,
-        },
-        fields="amount",
-        pluck="amount",
+    period_start = getdate(start_date)
+    period_end = getdate(end_date)
+    referrals_by_date, clicks_by_date = fetch_referral_and_click_buckets(
+        sales_partner, period_start, period_end
     )
-    void_sales = frappe.get_all(
-        "Affiliate Referral",
-        filters={
-            "sales_partner": sales_partner,
-            "record_type": "void",
-            "date": ["between", [start_datetime, end_datetime]],
-            "void": 0,
-        },
-        fields="amount",
-        pluck="amount",
-    )
-    sales_count = len(sales)
-    total_referral_fee = sum(sales) - sum(void_sales)
-
-    clicks_count = frappe.db.count(
-        "Affiliate Click Log",
-        filters={
-            "sales_partner": sales_partner,
-            "time": ["between", [start_datetime, end_datetime]],
-        },
-    )
-    unique_clicks_count = frappe.get_all(
-        "Affiliate Click Log",
-        filters={
-            "sales_partner": sales_partner,
-            "time": ["between", [start_datetime, end_datetime]],
-        },
-        fields=["remote_address"],
-        group_by="remote_address",
-    )
-
-    return {
-        "transactions": sales_count,
-        "referral_fee_earned": total_referral_fee,
-        "clicks": clicks_count or 0,
-        "unique_clicks": len(unique_clicks_count) or 0,
-    }
+    return aggregate_period(referrals_by_date, clicks_by_date, period_start, period_end)

--- a/frappe_affiliate/api/affiliate_statistics.py
+++ b/frappe_affiliate/api/affiliate_statistics.py
@@ -10,6 +10,11 @@ from frappe.utils import (
     getdate,
 )
 
+from frappe_affiliate.utils.statistics import (
+    aggregate_period,
+    fetch_referral_and_click_buckets,
+)
+
 
 @frappe.whitelist()
 def get_affiliate_statistics(
@@ -51,6 +56,15 @@ def get_monthly_statistics(affiliate_join, start, limit):
     if start_date < affiliate_join_date:
         start_date = affiliate_join_date
 
+    sales_partner = frappe.db.get_value(
+        "Sales Partner", {"custom_user": frappe.session.user}, "name"
+    )
+    # Fetch the whole window once and aggregate each month in memory to avoid per-month
+    # queries. get_period_statistics remains the standalone single-period version.
+    referrals_by_date, clicks_by_date = fetch_referral_and_click_buckets(
+        sales_partner, get_first_day(end_date), get_last_day(start_date)
+    )
+
     monthly_data = []
 
     total_dict = {
@@ -65,7 +79,9 @@ def get_monthly_statistics(affiliate_join, start, limit):
         month_start = get_first_day(current_month)
         month_end = get_last_day(current_month)
 
-        stats = get_period_statistics(month_start, month_end)
+        stats = aggregate_period(
+            referrals_by_date, clicks_by_date, month_start, month_end
+        )
         stats["period"] = formatdate(month_start, "yyyy-MM")
         stats["period_label"] = formatdate(month_start, "MMMM yyyy")
 
@@ -105,6 +121,14 @@ def get_daily_statistics(month):
     except (ValueError, AttributeError):
         return {"error": "Invalid month format. Use YYYY-MM"}
 
+    sales_partner = frappe.db.get_value(
+        "Sales Partner", {"custom_user": frappe.session.user}, "name"
+    )
+    # Fetch the whole month once and aggregate each day in memory to avoid per-day queries.
+    referrals_by_date, clicks_by_date = fetch_referral_and_click_buckets(
+        sales_partner, month_start, month_end
+    )
+
     daily_data = []
 
     total_dict = {
@@ -116,7 +140,9 @@ def get_daily_statistics(month):
 
     current_day = month_start
     while current_day <= month_end:
-        stats = get_period_statistics(current_day, current_day)
+        stats = aggregate_period(
+            referrals_by_date, clicks_by_date, current_day, current_day
+        )
         stats["period"] = formatdate(current_day, "yyyy-MM-dd")
         stats["period_label"] = formatdate(current_day, "MMMM dd, yyyy")
 
@@ -136,8 +162,11 @@ def get_daily_statistics(month):
 
 
 def get_period_statistics(start_date, end_date):
-    """Get affiliate statistics for a specific period"""
+    """Get affiliate statistics for a specific period.
 
+    Standalone single-period helper kept for external callers. Delegates to the shared
+    bulk helpers so the void / transaction / click rules live in one place.
+    """
     sales_partner = frappe.db.get_value(
         "Sales Partner", {"custom_user": frappe.session.user}, "name"
     )
@@ -150,48 +179,12 @@ def get_period_statistics(start_date, end_date):
             "unique_clicks": 0,
         }
 
-    start_datetime = frappe.utils.get_datetime(start_date)
-    end_datetime = frappe.utils.get_datetime(end_date).replace(
-        hour=23, minute=59, second=59
+    period_start = getdate(start_date)
+    period_end = getdate(end_date)
+    referrals_by_date, clicks_by_date = fetch_referral_and_click_buckets(
+        sales_partner, period_start, period_end
     )
-
-    sales = frappe.get_all(
-        "Affiliate Referral",
-        filters={
-            "sales_partner": sales_partner,
-            "record_type": "referral",
-            "date": ["between", [start_datetime, end_datetime]],
-            "void": 0,
-        },
-        fields="amount",
-        pluck="amount",
-    )
-    sales_count = len(sales)
-    total_referral_fee = sum(sales)
-
-    clicks_count = frappe.db.count(
-        "Affiliate Click Log",
-        filters={
-            "sales_partner": sales_partner,
-            "time": ["between", [start_datetime, end_datetime]],
-        },
-    )
-    unique_clicks_count = frappe.get_all(
-        "Affiliate Click Log",
-        filters={
-            "sales_partner": sales_partner,
-            "time": ["between", [start_datetime, end_datetime]],
-        },
-        fields=["remote_address"],
-        group_by="remote_address",
-    )
-
-    return {
-        "transactions": sales_count,
-        "referral_fee_earned": total_referral_fee,
-        "clicks": clicks_count or 0,
-        "unique_clicks": len(unique_clicks_count) or 0,
-    }
+    return aggregate_period(referrals_by_date, clicks_by_date, period_start, period_end)
 
 
 @frappe.whitelist(methods=["GET"])

--- a/frappe_affiliate/utils/statistics.py
+++ b/frappe_affiliate/utils/statistics.py
@@ -62,8 +62,7 @@ def aggregate_period(referrals_by_date, clicks_by_date, period_start, period_end
 
     Single source of truth for the void / transaction / click rules (no DB queries):
       - referral_fee_earned = sum(all referral amounts) - sum(void amounts), rounded to
-        currency precision. Voided referrals stay positive; the void record carries the
-        deduction (and its own date, which may fall in a later period), so a partial void
+        2 decimal places. Voided referrals stay positive; the void record carries the
         keeps its remaining fee.
       - transactions = count of all referrals (a referral that earned commission counts
         even if later voided); the void's earnings impact is still netted above.

--- a/frappe_affiliate/utils/statistics.py
+++ b/frappe_affiliate/utils/statistics.py
@@ -1,0 +1,86 @@
+from collections import defaultdict
+
+import frappe
+from frappe.utils import flt, get_datetime, getdate
+
+
+def fetch_referral_and_click_buckets(sales_partner, range_start, range_end):
+    """Bulk-fetch referral/void and click rows for [range_start, range_end], bucketed by date.
+
+    Single source of truth for the bulk statistics paths in both affiliate_statistics
+    (monthly/daily) and affiliate_advanced_statistics (grouped). Resolve the Sales Partner
+    in the caller and pass it in; aggregate each period from the returned buckets with
+    aggregate_period().
+
+    Returns (referrals_by_date, clicks_by_date):
+        referrals_by_date[date] = {
+            "referral": [amount, ...],             # every referral row, incl. voided ones
+            "void":     [amount, ...],             # void records (deductions)
+        }
+        clicks_by_date[date] = [remote_address, ...]
+    """
+    referrals_by_date = defaultdict(lambda: {"referral": [], "void": []})
+    clicks_by_date = defaultdict(list)
+
+    if not sales_partner:
+        return referrals_by_date, clicks_by_date
+
+    start_datetime = get_datetime(range_start)
+    end_datetime = get_datetime(range_end).replace(
+        hour=23, minute=59, second=59, microsecond=999999
+    )
+
+    # No void filter: voided referrals must stay in as positive entries so the void records
+    # (subtracted in aggregate_period) net them out — a partial void only removes the
+    # returned fraction, leaving the remaining fee intact.
+    for r in frappe.get_all(
+        "Affiliate Referral",
+        filters={
+            "sales_partner": sales_partner,
+            "record_type": ["in", ["referral", "void"]],
+            "date": ["between", [range_start, range_end]],
+        },
+        fields=["date", "amount", "record_type"],
+    ):
+        referrals_by_date[r.date][r.record_type].append(r.amount)
+
+    for c in frappe.get_all(
+        "Affiliate Click Log",
+        filters={
+            "sales_partner": sales_partner,
+            "time": ["between", [start_datetime, end_datetime]],
+        },
+        fields=["time", "remote_address"],
+    ):
+        clicks_by_date[getdate(c.time)].append(c.remote_address)
+
+    return referrals_by_date, clicks_by_date
+
+
+def aggregate_period(referrals_by_date, clicks_by_date, period_start, period_end):
+    """Aggregate one period's stats from the buckets produced by fetch_referral_and_click_buckets.
+
+    Single source of truth for the void / transaction / click rules (no DB queries):
+      - referral_fee_earned = sum(all referral amounts) - sum(void amounts), rounded to
+        currency precision. Voided referrals stay positive; the void record carries the
+        deduction (and its own date, which may fall in a later period), so a partial void
+        keeps its remaining fee.
+      - transactions = count of all referrals (a referral that earned commission counts
+        even if later voided); the void's earnings impact is still netted above.
+      - unique_clicks unions IPs across every date in the period (correct cross-day dedup;
+        a per-day SQL DISTINCT summed across days would overcount multi-day periods).
+    """
+    period_dates = [d for d in referrals_by_date if period_start <= d <= period_end]
+    sales = [a for d in period_dates for a in referrals_by_date[d]["referral"]]
+    void_amounts = [a for d in period_dates for a in referrals_by_date[d]["void"]]
+
+    click_dates = [d for d in clicks_by_date if period_start <= d <= period_end]
+    clicks_count = sum(len(clicks_by_date[d]) for d in click_dates)
+    unique_clicks = len({ip for d in click_dates for ip in clicks_by_date[d]})
+
+    return {
+        "transactions": len(sales),
+        "referral_fee_earned": flt(sum(sales) - sum(void_amounts), 2),
+        "clicks": clicks_count,
+        "unique_clicks": unique_clicks,
+    }


### PR DESCRIPTION
## Description

This pull request refactors the affiliate statistics code to centralize and optimize the logic for aggregating referral and click data. The main changes are the introduction of shared utility functions for bulk-fetching and aggregating statistics, which are now used across both the basic and advanced statistics APIs. This reduces repeated queries, ensures consistent business logic, and improves performance for period-based statistics.

Core refactor: shared aggregation and fetch logic

* Added new utility functions `fetch_referral_and_click_buckets` and `aggregate_period` in `frappe_affiliate/utils/statistics.py` to provide a single source of truth for fetching and aggregating referral and click data. These functions efficiently bulk-fetch data for a given period and aggregate statistics in memory, handling all business rules for voids, transactions, and unique clicks.

API updates: use shared helpers and reduce queries

* Updated `frappe_affiliate/api/affiliate_advanced_statistics.py` and `frappe_affiliate/api/affiliate_statistics.py` to use the new shared utility functions for all period-based statistics (daily, monthly, grouped), replacing previous per-period and per-query logic with in-memory aggregation from a single bulk fetch. This eliminates N+1 query patterns and ensures consistent calculation rules. [[1]](diffhunk://#diff-6a17b58705ac7366b7bb8ae6f6da5f6e8fd5f1f8c420436db8b8aa4c9c8f4551L335-L384) [[2]](diffhunk://#diff-6a17b58705ac7366b7bb8ae6f6da5f6e8fd5f1f8c420436db8b8aa4c9c8f4551L431-R407) [[3]](diffhunk://#diff-6a17b58705ac7366b7bb8ae6f6da5f6e8fd5f1f8c420436db8b8aa4c9c8f4551L487-R438) [[4]](diffhunk://#diff-02bc8c5f319ca6b7c20c5336be3793b4ff02a7572db0d4cc2899e27e80a7a356R59-R67) [[5]](diffhunk://#diff-02bc8c5f319ca6b7c20c5336be3793b4ff02a7572db0d4cc2899e27e80a7a356L68-R84) [[6]](diffhunk://#diff-02bc8c5f319ca6b7c20c5336be3793b4ff02a7572db0d4cc2899e27e80a7a356R124-R131) [[7]](diffhunk://#diff-02bc8c5f319ca6b7c20c5336be3793b4ff02a7572db0d4cc2899e27e80a7a356L119-R145) [[8]](diffhunk://#diff-02bc8c5f319ca6b7c20c5336be3793b4ff02a7572db0d4cc2899e27e80a7a356L139-R169) [[9]](diffhunk://#diff-02bc8c5f319ca6b7c20c5336be3793b4ff02a7572db0d4cc2899e27e80a7a356L153-R187)

Code cleanup and documentation

* Removed now-redundant imports and old aggregation logic, and improved docstrings to clarify the purpose and usage of the new shared helpers. [[1]](diffhunk://#diff-6a17b58705ac7366b7bb8ae6f6da5f6e8fd5f1f8c420436db8b8aa4c9c8f4551L1-R16) [[2]](diffhunk://#diff-02bc8c5f319ca6b7c20c5336be3793b4ff02a7572db0d4cc2899e27e80a7a356R13-R17) F9bebaccL162R162)

These changes make the statistics code more maintainable, performant, and less error-prone by consolidating all aggregation logic and business rules into a single, well-documented location.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #